### PR TITLE
fix(mobile): unblock file tree and git commit input on touch devices

### DIFF
--- a/frontend/src/components/editor/EditorTabs.tsx
+++ b/frontend/src/components/editor/EditorTabs.tsx
@@ -23,6 +23,16 @@ export function EditorTabs({ files, activeFileId, onSelect, onClose }: EditorTab
   const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
 
   const handleContextMenu = useCallback((e: React.MouseEvent, fileId: string) => {
+    // Same mobile guard as FileTree: touch long-press must not open the
+    // menu or trigger native selection. Only real right-click (or macOS
+    // Ctrl/Cmd+click) shows the tab menu.
+    const ne = e.nativeEvent;
+    const isRightClick = e.button === 2;
+    const isCtrlClick = e.ctrlKey || e.metaKey;
+    const isTouch = (ne as PointerEvent).pointerType === 'touch' || (ne as PointerEvent).pointerType === 'pen';
+    if (isTouch || (!isRightClick && !isCtrlClick)) {
+      return;
+    }
     e.preventDefault();
     setContextMenu({ x: e.clientX, y: e.clientY, fileId });
   }, []);

--- a/frontend/src/components/sidebar/FileTree.tsx
+++ b/frontend/src/components/sidebar/FileTree.tsx
@@ -174,6 +174,18 @@ export function FileTree({ rootPath, onFileSelect, refreshKey }: FileTreeProps) 
   }, [onFileSelect]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent, node: TreeNode | null) => {
+    // Mobile: on touch devices a long-press fires `contextmenu` too, and
+    // showing the menu at the finger position pops it over the bottom nav /
+    // tree and blocks scrolling & tapping. Only real mouse right-clicks (or
+    // Ctrl/Cmd+click on macOS) should show the menu. Suppress the native
+    // long-press callout as well.
+    const ne = e.nativeEvent;
+    const isRightClick = e.button === 2;
+    const isCtrlClick = e.ctrlKey || e.metaKey;
+    const isTouch = (ne as PointerEvent).pointerType === 'touch' || (ne as PointerEvent).pointerType === 'pen';
+    if (isTouch || (!isRightClick && !isCtrlClick)) {
+      return; // swallow silently — no menu, no native callout
+    }
     e.preventDefault();
     e.stopPropagation();
     setContextMenu({ x: e.clientX, y: e.clientY, node });

--- a/frontend/src/styles/ide/base.css
+++ b/frontend/src/styles/ide/base.css
@@ -50,3 +50,34 @@ body {
   min-height: 0;
   overflow: hidden;
 }
+
+/* IDE chrome must be non-selectable: on touch devices a long-press on any
+   chrome surface (sidebar tree, bottom nav, tabs, chat) otherwise starts a
+   native text-selection that highlights labels and swallows the touch /
+   pops the OS callout. Only the editor content (Monaco, inside
+   .workspace-editor / .editor-host / etc.) must remain selectable, so keep
+   this scoped to chrome containers. */
+.ide-shell .activity-bar,
+.ide-shell .workspace-sidebar,
+.ide-shell .workspace-chat,
+.ide-shell .bottom-nav,
+.ide-shell .editor-tabs,
+.ide-shell .workspace-terminal,
+.ide-shell .picker-shell,
+.ide-shell .workspace-browser {
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+
+/* The editor's own content stays selectable (Monaco needs selection). */
+.workspace-editor,
+.workspace-editor *,
+.workspace-browser .browser-viewport,
+.workspace-browser .browser-viewport *,
+.ide-shell .terminal-panel .xterm,
+.ide-shell .terminal-panel .xterm * {
+  user-select: auto;
+  -webkit-user-select: auto;
+  -webkit-touch-callout: default;
+}

--- a/frontend/src/styles/ide/file-tree.css
+++ b/frontend/src/styles/ide/file-tree.css
@@ -18,6 +18,23 @@
   font-size: 0.85rem;
   text-align: left;
   transition: background 0.12s ease;
+  /* Mobile-friendly: prevent text selection on tap & long-press, and let
+     taps register as clicks instead of scroll gestures. */
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Larger, comfortable tap targets on touch devices (>= ~44px tall).
+   Keeps the compact desktop density untouched. */
+@media (hover: none), (pointer: coarse) {
+  .tree-row {
+    padding-top: 9px;
+    padding-bottom: 9px;
+    min-height: 40px;
+    font-size: 0.9rem;
+  }
 }
 
 .tree-row:hover {

--- a/frontend/src/styles/ide/overlays.css
+++ b/frontend/src/styles/ide/overlays.css
@@ -427,6 +427,27 @@
     pointer-events: auto;
   }
 
+  /* CRITICAL mobile fix: .workspace-center (the editor container) is
+     position:absolute; inset:0 and paints AFTER the sidebar in DOM order,
+     so with default pointer-events:auto it silently covers the sidebar and
+     swallows every touch meant for the file tree / git commit input.
+     When a sidebar-based view is active, take the center out of the hit-test
+     path entirely so taps reach the sidebar. The editor gets its own touch
+     back (below) when it is the active view. */
+  .mobile-view-explorer .workspace-center,
+  .mobile-view-projects .workspace-center,
+  .mobile-view-git .workspace-center,
+  .mobile-view-settings .workspace-center {
+    pointer-events: none;
+  }
+
+  /* Restore pointer-events on actual children the editor needs for
+     interaction (Monaco) — only within the editor view, so the overlay
+     rule above still keeps the center transparent to sidebar taps. */
+  .mobile-view-editor .workspace-center {
+    pointer-events: auto;
+  }
+
   .bottom-nav {
     display: flex;
   }


### PR DESCRIPTION
## Summary

On phones/tablets (max-width: 767px), the mobile layout shows full-screen **panels** (explorer / git / projects / settings) switched via the bottom nav — there is no desktop-style sidebar. Two bugs made those panels unusable on touch:

1. **Taps and scroll gestures on the file tree / git commit box were swallowed.** The editor panel (`.workspace-center`) is `position:absolute; inset:0` and paints **after** the other panels in DOM order, so with default `pointer-events:auto` it silently covers them and eats touch input.
2. **Long-press highlighted text / popped the context menu.** A long-press on a tree row or editor tab triggered the native text-selection callout (highlighting labels like the bottom-nav "Files") and opened 9ed's context menu at the finger position, blocking scrolling and further taps.

## Bug demo

The screen recording below shows the first symptom on a real device: a drag/scroll gesture on the file tree leaves the list **completely static** — the gesture never reaches the tree's scroll container because the overlapping editor panel intercepts it. The fix removes `.workspace-center` from the hit-test path in panel-based views, so scroll and tap events reach the file tree (verified: tapping a folder expands it, and the tree scrolls).

https://github.com/user-attachments/assets/4df19256-0266-4b88-8838-4c19dab9de4d

## Changes

- **`frontend/src/styles/ide/overlays.css`** — in mobile **panel-based** views (explorer / projects / git / settings), set `.workspace-center` to `pointer-events:none` so taps reach the active panel; restored only in the editor view.
- **`frontend/src/styles/ide/base.css`** — IDE chrome (activity bar, panels, bottom nav, tabs, chat, terminal, picker, browser panel) is now `user-select:none` + `-webkit-touch-callout:none`, so long-press never starts a native selection; Monaco editor content stays selectable.
- **`frontend/src/components/sidebar/FileTree.tsx`** & **`frontend/src/components/editor/EditorTabs.tsx`** — context menu only opens on a real mouse right-click (or macOS Ctrl/Cmd+click); touch/pen `contextmenu` is ignored so a long-press doesn't pop the menu over the UI.
- **`frontend/src/styles/ide/file-tree.css`** — `.tree-row` gets `user-select:none`, `touch-action:manipulation`, `-webkit-tap-highlight-color:transparent`; on coarse-pointer devices rows get ~40px tap targets while desktop density is unchanged.

## Verification

Tested with real touch events (CDP `Input.dispatchTouchEvent` with mobile emulation) against the built app:
- Tap a folder → expands (94 → 107 rows) ✅
- Long-press → selects nothing, opens no menu ✅
- Git commit textarea → focuses and accepts input ✅

No backend changes. Desktop behavior is unchanged (context-menu guard passes through real right-clicks; chrome no-select scoped to IDE chrome, editor still selectable).
